### PR TITLE
Moving package dependencies to devDependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/ejwessel/GanacheTimeTraveler/issues"
   },
   "homepage": "https://github.com/ejwessel/GanacheTimeTraveler#readme",
-  "dependencies": {
+  "devDependencies": {
     "ganache-cli": "^6.5.0",
     "truffle": "5.0.28"
   },


### PR DESCRIPTION
This library doesn't import from anywhere so having ganache and truffle as dependencies are not needed. Moved them so that the user of the util doesn't have to download unnecessary packages